### PR TITLE
fix: stop running watchdog once it expires, even on systemd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,33 +168,40 @@ jobs:
 
     env:
       DOCKER_BUILDKIT: 1
+      HAVE_DOCKER_CREDS: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''}}
 
     steps:
       - name: Checkout Repository
+        if: ${{ env.HAVE_DOCKER_CREDS }}
         uses: actions/checkout@v4
 
       - name: Get Version Number
         shell: bash
+        if: ${{ env.HAVE_DOCKER_CREDS }}
         run: echo "PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
 
       # https://github.com/docker/setup-qemu-action
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
+        if: ${{ env.HAVE_DOCKER_CREDS }}
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
+        if: ${{ env.HAVE_DOCKER_CREDS }}
         with:
           buildkitd-flags: "--debug"
 
       - name: Login to Dockerhub
         uses: docker/login-action@v2
+        if: ${{ env.HAVE_DOCKER_CREDS }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: ${{ env.HAVE_DOCKER_CREDS }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -202,6 +209,7 @@ jobs:
 
       - name: Docker Build and Push
         uses: docker/build-push-action@v4
+        if: ${{ env.HAVE_DOCKER_CREDS }}
         with:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/bottle-time-processor:latest
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/bottle-time-processor:latest,mode=max


### PR DESCRIPTION
build: dont try to publish to docker hub if we dont have creds

