### PR TITLE
test: Add more tests for command_line and add tests to verify more of our mqtt_client setup.

### DIFF
--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -82,7 +82,12 @@ where
         1 => tracing::Level::DEBUG,
         _ => tracing::Level::TRACE,
     };
-    tracing_subscriber::fmt().with_max_level(debug_level).init();
+    if let Err(e) = tracing_subscriber::fmt()
+        .with_max_level(debug_level)
+        .try_init()
+    {
+        eprintln!("Failed to set global subscriber: {}", e);
+    }
 
     opts
 }
@@ -142,6 +147,57 @@ mod tests {
             "bucket",
         ];
         let opts = parse(Some(args.iter().map(|x| x.to_string())));
+
+        assert_eq!(opts.influxdb_token, "token");
+        assert_eq!(opts.influxdb_org, "org");
+        assert_eq!(opts.influxdb_bucket, "bucket");
+    }
+
+    #[test]
+    fn test_verbose() {
+        let args = vec![
+            "bottle-time-processor",
+            "-v",
+            "--influxdb-token",
+            "token",
+            "--influxdb-org",
+            "org",
+            "--influxdb-bucket",
+            "bucket",
+        ];
+        let opts = parse(Some(args.iter().map(|x| x.to_string())));
+
+        assert_eq!(opts.verbose, 1);
+    }
+
+    #[test]
+    fn test_very_verbose() {
+        let args = vec![
+            "bottle-time-processor",
+            "-vv",
+            "--influxdb-token",
+            "token",
+            "--influxdb-org",
+            "org",
+            "--influxdb-bucket",
+            "bucket",
+        ];
+        let opts = parse(Some(args.iter().map(|x| x.to_string())));
+
+        assert_eq!(opts.verbose, 2);
+    }
+
+    #[ignore]
+    #[test]
+    /// Not yet working, this test fails because the "args" that clap picks up are the args
+    /// from the test command. I don't know how to fix this yet.
+    fn test_all_args() {
+        unsafe {
+            std::env::set_var("INFLUX_TOKEN", "token");
+            std::env::set_var("INFLUX_ORG", "org");
+            std::env::set_var("INFLUX_BUCKET", "bucket");
+        }
+        let opts = parse::<Vec<String>>(None);
 
         assert_eq!(opts.influxdb_token, "token");
         assert_eq!(opts.influxdb_org, "org");

--- a/src/influxdb.rs
+++ b/src/influxdb.rs
@@ -2,12 +2,25 @@ use crate::models::PowerReading;
 use futures::stream;
 use influxdb2::Client;
 use miette::{Error, Report, Result};
+use std::fmt::{Display, Formatter};
 
 /// A writer for InfluxDB
 #[derive(Debug, Clone)]
 pub struct InfluxDBWriter {
     client: Client,
     bucket: String,
+}
+
+impl Display for InfluxDBWriter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InfluxDBWriter {{ client: {{ url: {:?}, org: {:?}, }}, bucket: {:?} }}",
+            self.client.base.to_string(),
+            self.client.org,
+            self.bucket
+        )
+    }
 }
 
 impl InfluxDBWriter {

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -7,50 +7,132 @@ use rumqttc::MqttOptions;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 
+const PROC_NAME: &str = "bottle_time_processor";
+
 pub async fn setup_mqtt(
     opts: &crate::command_line::Options,
     reset_tx: Option<Sender<Signal>>,
 ) -> miette::Result<MqttClientManager> {
-    let mut mqttoptions = MqttOptions::new("bottle_time_processor", opts.broker.clone(), opts.port);
-    mqttoptions.set_keep_alive(Duration::from_secs(5));
-    mqttoptions.set_credentials(opts.username.clone(), opts.password.clone());
-
+    let mqttoptions = configure_mqtt_options(opts);
     let (mqtt_client_manager, eventloop) = MqttClientManager::new(mqttoptions)?;
 
-    let influxdb = InfluxDBWriter::new(
-        opts.influxdb_url.clone(),
-        opts.influxdb_org.clone(),
-        opts.influxdb_token.clone(),
-        opts.influxdb_bucket.clone(),
-    );
+    let influxdb = create_influxdb_writer(opts);
 
-    mqtt_client_manager
-        .subscribe(opts.topic.clone(), None, move |message| {
-            let influxdb = influxdb.clone();
-            let reset_tx_clone = reset_tx.clone();
-            Box::pin(async move {
-                let power_message: KasaPowerMessage =
-                    serde_json::from_str(message.as_str()).with_serde_json_context()?;
-                let readings = power_message.into_readings();
-                for reading in readings {
-                    tracing::debug!("Writing reading to InfluxDB: {:?}", reading);
-                    influxdb
-                        .write_power_reading(&reading)
-                        .await
-                        .expect("Failed to write power reading to InfluxDB");
-                }
-                tracing::info!("Resetting watchdog timer");
-                let _x = match reset_tx_clone {
-                    Some(tx) => tx.send(Signal::Reset).await,
-                    None => Ok(()),
-                };
-
-                Ok(())
-            })
-        })
-        .await?;
+    subscribe_to_topic(&mqtt_client_manager, opts, influxdb, reset_tx).await?;
 
     mqtt_client_manager.spawn_event_handler(eventloop).await?;
 
     Ok(mqtt_client_manager)
+}
+
+fn configure_mqtt_options(opts: &crate::command_line::Options) -> MqttOptions {
+    let mut mqttoptions = MqttOptions::new(PROC_NAME, opts.broker.clone(), opts.port);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
+    mqttoptions.set_credentials(opts.username.clone(), opts.password.clone());
+    mqttoptions
+}
+
+fn create_influxdb_writer(opts: &crate::command_line::Options) -> InfluxDBWriter {
+    InfluxDBWriter::new(
+        opts.influxdb_url.clone(),
+        opts.influxdb_org.clone(),
+        opts.influxdb_token.clone(),
+        opts.influxdb_bucket.clone(),
+    )
+}
+
+async fn subscribe_to_topic(
+    mqtt_client_manager: &MqttClientManager,
+    opts: &crate::command_line::Options,
+    influxdb: InfluxDBWriter,
+    reset_tx: Option<Sender<Signal>>,
+) -> miette::Result<()> {
+    mqtt_client_manager
+        .subscribe(opts.topic.clone(), None, move |message| {
+            let influxdb = influxdb.clone();
+            let reset_tx_clone = reset_tx.clone();
+            Box::pin(
+                async move { process_message(message.as_str(), &influxdb, reset_tx_clone).await },
+            )
+        })
+        .await
+}
+
+async fn process_message(
+    message: &str,
+    influxdb: &InfluxDBWriter,
+    reset_tx: Option<Sender<Signal>>,
+) -> miette::Result<()> {
+    let power_message: KasaPowerMessage =
+        serde_json::from_str(message).with_serde_json_context()?;
+    let readings = power_message.into_readings();
+
+    for reading in readings {
+        tracing::debug!("Writing reading to InfluxDB: {:?}", reading);
+        influxdb
+            .write_power_reading(&reading)
+            .await
+            .expect("Failed to write power reading to InfluxDB");
+    }
+
+    tracing::info!("Resetting watchdog timer");
+
+    if let Some(tx) = reset_tx {
+        tx.send(Signal::Reset).await.ok();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_line::Options;
+    use clap::Parser;
+
+    fn get_default_opts() -> Options {
+        Options::try_parse_from(
+            vec![
+                "bottle-time-processor",
+                "--influxdb-token",
+                "token",
+                "--influxdb-org",
+                "org",
+                "--influxdb-bucket",
+                "bucket",
+                "--broker",
+                "test_broker",
+                "--username",
+                "user",
+                "--password",
+                "pass",
+            ]
+            .iter(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_configure_mqtt_options() {
+        let opts = get_default_opts();
+
+        let mqtt_options = configure_mqtt_options(&opts);
+
+        assert_eq!(
+            mqtt_options.broker_address(),
+            ("test_broker".to_string(), 1883)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_influxdb_writer() {
+        let opts = get_default_opts();
+
+        let writer = create_influxdb_writer(&opts);
+
+        assert_eq!(
+            writer.to_string(),
+            "InfluxDBWriter { client: { url: \"http://localhost:8086/\", org: \"org\", }, bucket: \"bucket\" }"
+        );
+    }
 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -89,9 +89,32 @@ impl std::fmt::Debug for Subscription {
     }
 }
 
-/// MQTT Client Manager
-pub struct MqttClientManager {
+/// An abstraction over the MQTT client functionality allowing dependency injection.
+#[async_trait]
+pub trait MqttClientInterface: Send + Sync + Debug {
+    /// Subscribe to a topic with a given QoS
+    async fn subscribe(&self, topic: &str, qos: QoS) -> Result<()>;
+}
+
+/// The production implementation wrapping `rumqttc`’s `AsyncClient`.
+#[derive(Debug)]
+pub struct RealMqttClient {
     client: AsyncClient,
+}
+
+#[async_trait]
+impl MqttClientInterface for RealMqttClient {
+    async fn subscribe(&self, topic: &str, qos: QoS) -> Result<()> {
+        // The real client subscribes to the topic and sets up subscription context.
+        let sub = self.client.subscribe(topic, qos).await;
+        sub.with_subscription_context(topic)?;
+        Ok(())
+    }
+}
+
+/// The MQTT client manager
+pub struct MqttClientManager {
+    client: Arc<dyn MqttClientInterface>,
     subscriptions: Arc<Mutex<HashMap<String, Vec<Subscription>>>>,
 }
 
@@ -99,13 +122,16 @@ impl MqttClientManager {
     /// Create a new MQTT client manager
     pub fn new(mqtt_options: MqttOptions) -> Result<(Self, EventLoop)> {
         let (client, eventloop) = AsyncClient::new(mqtt_options, 10);
-        Ok((
-            Self {
-                client,
-                subscriptions: Arc::new(Mutex::new(HashMap::new())),
-            },
-            eventloop,
-        ))
+        let real_client = RealMqttClient { client };
+        Ok((Self::with_client(Arc::new(real_client)), eventloop))
+    }
+
+    /// Alternative constructor to allow injection of a custom client (for tests).
+    pub fn with_client(client: Arc<dyn MqttClientInterface>) -> Self {
+        Self {
+            client,
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 
     /// Subscribe to a topic with an optional filter and callback
@@ -122,10 +148,7 @@ impl MqttClientManager {
 
         // Subscribe to MQTT topic if this is the first subscription
         if !subs.contains_key(&topic) {
-            self.client
-                .subscribe(&topic, QoS::AtMostOnce)
-                .await
-                .with_subscription_context(&topic)?;
+            self.client.subscribe(&topic, QoS::AtMostOnce).await?;
             subs.insert(topic.clone(), Vec::new());
         }
 
@@ -222,6 +245,31 @@ impl std::fmt::Debug for MqttClientManager {
 mod tests {
     use super::*;
 
+    #[derive(Debug)]
+    struct FakeMqttClient {
+        // This field records subscribe calls for later verification.
+        pub subscribe_calls: Mutex<Vec<(String, QoS)>>,
+    }
+
+    impl FakeMqttClient {
+        fn new() -> Self {
+            Self {
+                subscribe_calls: Mutex::new(vec![]),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MqttClientInterface for FakeMqttClient {
+        async fn subscribe(&self, topic: &str, qos: QoS) -> Result<()> {
+            self.subscribe_calls
+                .lock()
+                .await
+                .push((topic.to_string(), qos));
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_contains_filter() {
         let filter = ContainsFilter("test".to_string());
@@ -272,10 +320,24 @@ mod tests {
         assert_eq!(format!("{:?}", func), "FunctionFilter(\"<function>\")");
     }
 
+    fn get_msg_cb(expected_msg: String) -> MessageCallback {
+        Box::new(move |msg: String| {
+            Box::pin({
+                {
+                    let value = expected_msg.clone();
+                    async move {
+                        assert_eq!(msg, value);
+                        Ok(())
+                    }
+                }
+            })
+        })
+    }
+
     #[tokio::test]
     async fn test_handle_message() {
         let manager = MqttClientManager {
-            client: AsyncClient::new(MqttOptions::new("test", "localhost", 1883), 10).0,
+            client: Arc::new(FakeMqttClient::new()),
             subscriptions: Arc::new(Mutex::new(HashMap::new())),
         };
 
@@ -284,14 +346,7 @@ mod tests {
 
         let filter = ContainsFilter("test".to_string());
 
-        let callback: MessageCallback = Box::new(|msg: String| {
-            Box::pin({
-                async move {
-                    assert_eq!(msg, "test message");
-                    Ok(())
-                }
-            })
-        });
+        let callback: MessageCallback = get_msg_cb("test message".to_string());
 
         let subscription = Subscription {
             filter: Some(Box::new(filter)),
@@ -305,17 +360,34 @@ mod tests {
         manager.handle_message(&topic, &payload).await.unwrap();
     }
 
+    #[tokio::test]
+    async fn test_handle_message_none_filter() {
+        let manager = MqttClientManager {
+            client: Arc::new(FakeMqttClient::new()),
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        let topic = "test".to_string();
+        let payload = "test message".to_string();
+
+        let callback: MessageCallback = get_msg_cb("test message".to_string());
+
+        let subscription = Subscription {
+            filter: None,
+            callback: Box::new(callback),
+        };
+
+        {
+            let mut subs = manager.subscriptions.lock().await;
+            subs.insert(topic.clone(), vec![subscription]);
+        }
+        manager.handle_message(&topic, &payload).await.unwrap();
+    }
+
     #[test]
     fn test_format_for_subscription() {
         let filter = ContainsFilter("test".to_string());
-        let callback: MessageCallback = Box::new(|msg: String| {
-            Box::pin({
-                async move {
-                    assert_eq!(msg, "test message");
-                    Ok(())
-                }
-            })
-        });
+        let callback: MessageCallback = get_msg_cb("test message".to_string());
 
         let subscription = Subscription {
             filter: Some(Box::new(filter)),
@@ -331,7 +403,7 @@ mod tests {
     #[test]
     fn test_format_for_mqtt_manager() {
         let manager = MqttClientManager {
-            client: AsyncClient::new(MqttOptions::new("test", "localhost", 1883), 10).0,
+            client: Arc::new(FakeMqttClient::new()),
             subscriptions: Arc::new(Mutex::new(HashMap::new())),
         };
 
@@ -339,8 +411,51 @@ mod tests {
             format!("{:?}", manager),
             format!(
                 "MqttClientManager {{ client: {:?}, subscriptions: Mutex {{ data: {{}} }} }}",
-                AsyncClient::new(MqttOptions::new("test", "localhost", 1883), 10).0
+                FakeMqttClient::new()
             )
         )
+    }
+
+    #[tokio::test]
+    async fn test_new_mqtt_manager() {
+        let (manager, _) =
+            MqttClientManager::new(MqttOptions::new("test", "localhost", 1883)).unwrap();
+        assert_eq!(manager.subscriptions.lock().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mqtt_manager_subscribe() {
+        let manager = MqttClientManager {
+            client: Arc::new(FakeMqttClient::new()),
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        let topic = "test".to_string();
+        let filter = ContainsFilter("test".to_string());
+        let callback: MessageCallback = get_msg_cb("test message".to_string());
+
+        manager
+            .subscribe(topic.clone(), Some(Box::new(filter)), callback)
+            .await
+            .unwrap();
+
+        let subs = manager.subscriptions.lock().await;
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs.get(&topic).unwrap().len(), 1);
+    }
+
+    #[ignore]
+    /// This test is ignored because it requires a running MQTT broker
+    #[tokio::test]
+    async fn test_real_mqtt_client_interface_subscribe() {
+        let client = RealMqttClient {
+            client: AsyncClient::new(MqttOptions::new("test", "localhost", 1883), 10).0,
+        };
+
+        let topic = "test";
+        let qos = QoS::AtMostOnce;
+
+        let result = client.subscribe(topic, qos).await;
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
Add more tests for command_line and add tests to verify more of our mqtt_client setup.

The mqtt client setup mocks out the actual client in most tests now so that we can properly test just the MqttClientManager behavior of handling subscriptions and filters
