### PR TITLE
test: Split up influxdb to support client mocking and testing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,27 +43,13 @@ jobs:
       - name: Cache Project
         uses: Swatinem/rust-cache@v2
 
-      - run: mkdir -p ./target/debug/coverage
-
-#      - name: Generate Code coverage
-#        env:
-#          CARGO_INCREMENTAL: '0'
-#          LLVM_PROFILE_FILE: "target/debug/coverage/bottle-time-processor-%p-%m.profraw"
-#          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-#          RUSTDOCFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-#        run: cargo test --all-features
-
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
-      - name: Install grcov
-        run: "curl -L https://github.com/mozilla/grcov/releases/download/v0.8.12/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -"
-
       - name: Install covfix
-        uses: actions-rs/install@v0.1
+        uses: taiki-e/cache-cargo-install-action@v2
         with:
-          crate: rust-covfix
-          use-tool-cache: true
+          tool: rust-covfix
 
       - name: Run covfix
         run: rust-covfix lcov.info -o lcov.info --verbose

--- a/src/influxdb.rs
+++ b/src/influxdb.rs
@@ -1,32 +1,88 @@
 use crate::models::PowerReading;
+use async_trait::async_trait;
 use futures::stream;
-use influxdb2::Client;
+use influxdb2::{Client, models::DataPoint};
 use miette::{Error, Report, Result};
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Debug, Display, Formatter},
+    sync::Arc,
+};
 
-/// A writer for InfluxDB
-#[derive(Debug, Clone)]
+/// Define a trait to abstract the write operation for InfluxDB.
+#[async_trait]
+pub trait InfluxDbClient: Send + Sync + Display {
+    /// Writes a single data point to InfluxDB.
+    async fn write_data_point(&self, bucket: &str, point: DataPoint) -> Result<(), Error>;
+}
+
+struct ClientExt(Client);
+
+impl Display for ClientExt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{ url: {:?}, org: {:?}, }}",
+            self.0.base.to_string(),
+            self.0.org,
+        )
+    }
+}
+
+/// Implement the trait for the production InfluxDB client.
+#[async_trait]
+impl InfluxDbClient for ClientExt {
+    async fn write_data_point(&self, bucket: &str, point: DataPoint) -> Result<(), Error> {
+        self.0
+            .write(bucket, stream::iter(vec![point]))
+            .await
+            .map_err(|e| Report::from_err(e).wrap_err("Failed to write to InfluxDB"))
+    }
+}
+
+/// A writer for InfluxDB.
+///
+/// Instead of hardcoding a production client, we hold
+/// an Arc to a trait object so that you can swap in a fake/stub.
+#[derive(Clone)]
 pub struct InfluxDBWriter {
-    client: Client,
+    client: Arc<dyn InfluxDbClient>,
     bucket: String,
+}
+
+impl Debug for InfluxDBWriter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InfluxDBWriter {{ client: {}, bucket: \"{}\" }}",
+            self.client, self.bucket
+        )
+    }
 }
 
 impl Display for InfluxDBWriter {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "InfluxDBWriter {{ client: {{ url: {:?}, org: {:?}, }}, bucket: {:?} }}",
-            self.client.base.to_string(),
-            self.client.org,
-            self.bucket
+            "InfluxDBWriter {{ client: {}, bucket: \"{}\" }}",
+            self.client, self.bucket
         )
     }
 }
 
 impl InfluxDBWriter {
-    /// Creates a new InfluxDB writer with the given connection parameters
+    /// Creates a new InfluxDB writer using a real (production) client.
     pub fn new(url: String, org: String, token: String, bucket: String) -> Self {
-        let client = Client::new(url, org, token);
+        let client = ClientExt(Client::new(url, org, token));
+        Self {
+            client: Arc::new(client),
+            bucket,
+        }
+    }
+
+    /// Creates a new writer with a provided client.
+    ///
+    /// This is useful for testing where you provide a fake or stub implementation.
+    pub fn with_client(client: Arc<dyn InfluxDbClient>, bucket: String) -> Self {
         Self { client, bucket }
     }
 
@@ -44,10 +100,7 @@ impl InfluxDBWriter {
             .map_err(|e| Report::from_err(e).wrap_err("Failed to build InfluxDB point"))?;
 
         tracing::trace!("Writing power reading point to InfluxDB: {:?}", point);
-        self.client
-            .write(&self.bucket, stream::iter(vec![point]))
-            .await
-            .map_err(|e| Report::from_err(e).wrap_err("Failed to write to InfluxDB"))?;
+        self.client.write_data_point(&self.bucket, point).await?;
 
         Ok(())
     }

--- a/src/influxdb.rs
+++ b/src/influxdb.rs
@@ -105,3 +105,65 @@ impl InfluxDBWriter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_and_display_for_influxdbwriter() {
+        let writer = InfluxDBWriter::new(
+            "http://localhost:8086".to_string(),
+            "my-org".to_string(),
+            "my-token".to_string(),
+            "my-bucket".to_string(),
+        );
+        assert_eq!(
+            format!("{:?}", writer),
+            "InfluxDBWriter { client: { url: \"http://localhost:8086/\", org: \"my-org\", }, bucket: \"my-bucket\" }"
+        );
+        assert_eq!(
+            format!("{}", writer),
+            "InfluxDBWriter { client: { url: \"http://localhost:8086/\", org: \"my-org\", }, bucket: \"my-bucket\" }"
+        );
+    }
+
+    #[test]
+    fn test_display_for_clientext() {
+        let client = ClientExt(Client::new("http://localhost:8086", "my-org", "my-token"));
+        assert_eq!(
+            format!("{}", client),
+            "{ url: \"http://localhost:8086/\", org: \"my-org\", }"
+        );
+    }
+
+    #[test]
+    fn test_new_for_influxdbwriter() {
+        let writer = InfluxDBWriter::new(
+            "http://localhost:8086".to_string(),
+            "my-org".to_string(),
+            "my-token".to_string(),
+            "my-bucket".to_string(),
+        );
+        assert_eq!(writer.bucket, "my-bucket");
+        assert_eq!(
+            format!("{}", writer.client),
+            "{ url: \"http://localhost:8086/\", org: \"my-org\", }"
+        );
+    }
+
+    #[test]
+    fn test_with_client_for_influxdbwriter() {
+        let client = Arc::new(ClientExt(Client::new(
+            "http://localhost:8086",
+            "my-org",
+            "my-token",
+        )));
+        let writer = InfluxDBWriter::with_client(client.clone(), "my-bucket".to_string());
+        assert_eq!(writer.bucket, "my-bucket");
+        assert_eq!(
+            format!("{}", writer.client),
+            "{ url: \"http://localhost:8086/\", org: \"my-org\", }"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,21 @@ pub mod mqtt_client;
 /// InfluxDB client implementation
 pub mod influxdb;
 
+/// Watchdog Signal definition for use in tests and main
+pub mod watchdog {
+
+    /// Signal for interacting with the watchdog.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+    #[allow(dead_code)]
+    pub enum Signal {
+        /// Reset the watchdog.
+        #[default]
+        Reset,
+        /// Stop the watchdog timer.
+        Stop,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use tokio::sync::{
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
 mod command_line;
-
 mod mqtt;
 mod watchdog;
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -1,7 +1,7 @@
-use crate::watchdog::Signal;
 use bottle_time_processor::{
-    error::ResultExt, influxdb::InfluxDBWriter, models::KasaPowerMessage,
-    mqtt_client::MqttClientManager,
+    influxdb::InfluxDBWriter,
+    mqtt_client::{MqttClientManager, process_message},
+    watchdog::Signal,
 };
 use rumqttc::MqttOptions;
 use std::time::Duration;
@@ -58,80 +58,11 @@ async fn subscribe_to_topic(
         .await
 }
 
-async fn process_message(
-    message: &str,
-    influxdb: &InfluxDBWriter,
-    reset_tx: Option<Sender<Signal>>,
-) -> miette::Result<()> {
-    let power_message: KasaPowerMessage =
-        serde_json::from_str(message).with_serde_json_context()?;
-    let readings = power_message.into_readings();
-
-    for reading in readings {
-        tracing::debug!("Writing reading to InfluxDB: {:?}", reading);
-        influxdb
-            .write_power_reading(&reading)
-            .await
-            .expect("Failed to write power reading to InfluxDB");
-    }
-
-    tracing::info!("Resetting watchdog timer");
-
-    if let Some(tx) = reset_tx {
-        tx.send(Signal::Reset).await.ok();
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::command_line::Options;
-    use async_trait::async_trait;
-    use bottle_time_processor::influxdb::InfluxDbClient;
     use clap::Parser;
-    use influxdb2::models::{DataPoint, WriteDataPoint};
-    use std::{
-        fmt::{Display, Formatter},
-        sync::Arc,
-    };
-    use tokio::sync::Mutex;
-
-    //==========================================================================
-    // Fake InfluxDB Client for Testing
-    //==========================================================================
-    struct FakeInfluxDbClient {
-        pub data_points_written: Mutex<Vec<DataPoint>>,
-    }
-
-    impl FakeInfluxDbClient {
-        pub fn new() -> Self {
-            Self {
-                data_points_written: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl Display for FakeInfluxDbClient {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "client: Fake")
-        }
-    }
-
-    #[async_trait]
-    impl InfluxDbClient for FakeInfluxDbClient {
-        async fn write_data_point(
-            &self,
-            _bucket: &str,
-            point: DataPoint,
-        ) -> Result<(), miette::Error> {
-            let mut data_points = self.data_points_written.lock().await;
-            data_points.push(point);
-            // For testing, simply simulate a successful write.
-            Ok(())
-        }
-    }
 
     fn get_default_opts() -> Options {
         Options::try_parse_from(
@@ -176,34 +107,6 @@ mod tests {
         assert_eq!(
             writer.to_string(),
             "InfluxDBWriter { client: { url: \"http://localhost:8086/\", org: \"org\", }, bucket: \"bucket\" }"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_process_message() {
-        let fake_client = Arc::new(FakeInfluxDbClient::new());
-        // Mock setup
-        let mock_writer =
-            InfluxDBWriter::with_client(fake_client.clone(), "test_bucket".to_string());
-
-        // Sample power readings
-        let message = r#"{"alias":"dev01","deviceId":"1234","power_total":7,"voltages_mv":[119355,119355,119276,119276,119171,119171,119171],"currents_ma":[23,23,23,23,23,23,22],"powers_mw":[754,757,757,739,739,770,770],"timestamps":[1740947155686,1740947158755,1740947161665,1740947164698,1740947167764,1740947170665,1740947172914],"num_readings":7}"#;
-
-        let result = process_message(message, &mock_writer, None).await;
-
-        assert!(result.is_ok());
-
-        assert_eq!(fake_client.data_points_written.lock().await.len(), 7);
-
-        // Check the first data point
-        let dp1 = &fake_client.data_points_written.lock().await[0];
-        let mut v = Vec::new();
-        dp1.write_data_point_to(&mut v).unwrap();
-        let s = String::from_utf8(v).unwrap();
-
-        assert_eq!(
-            s,
-            "power_reading,device_id=1234,device_name=dev01 current_ma=23,power_mw=754,voltage_mv=119355 1740947155686000000\n"
         );
     }
 }

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -88,7 +88,50 @@ async fn process_message(
 mod tests {
     use super::*;
     use crate::command_line::Options;
+    use async_trait::async_trait;
+    use bottle_time_processor::influxdb::InfluxDbClient;
     use clap::Parser;
+    use influxdb2::models::{DataPoint, WriteDataPoint};
+    use std::{
+        fmt::{Display, Formatter},
+        sync::Arc,
+    };
+    use tokio::sync::Mutex;
+
+    //==========================================================================
+    // Fake InfluxDB Client for Testing
+    //==========================================================================
+    struct FakeInfluxDbClient {
+        pub data_points_written: Mutex<Vec<DataPoint>>,
+    }
+
+    impl FakeInfluxDbClient {
+        pub fn new() -> Self {
+            Self {
+                data_points_written: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Display for FakeInfluxDbClient {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "client: Fake")
+        }
+    }
+
+    #[async_trait]
+    impl InfluxDbClient for FakeInfluxDbClient {
+        async fn write_data_point(
+            &self,
+            _bucket: &str,
+            point: DataPoint,
+        ) -> Result<(), miette::Error> {
+            let mut data_points = self.data_points_written.lock().await;
+            data_points.push(point);
+            // For testing, simply simulate a successful write.
+            Ok(())
+        }
+    }
 
     fn get_default_opts() -> Options {
         Options::try_parse_from(
@@ -133,6 +176,34 @@ mod tests {
         assert_eq!(
             writer.to_string(),
             "InfluxDBWriter { client: { url: \"http://localhost:8086/\", org: \"org\", }, bucket: \"bucket\" }"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_message() {
+        let fake_client = Arc::new(FakeInfluxDbClient::new());
+        // Mock setup
+        let mock_writer =
+            InfluxDBWriter::with_client(fake_client.clone(), "test_bucket".to_string());
+
+        // Sample power readings
+        let message = r#"{"alias":"dev01","deviceId":"1234","power_total":7,"voltages_mv":[119355,119355,119276,119276,119171,119171,119171],"currents_ma":[23,23,23,23,23,23,22],"powers_mw":[754,757,757,739,739,770,770],"timestamps":[1740947155686,1740947158755,1740947161665,1740947164698,1740947167764,1740947170665,1740947172914],"num_readings":7}"#;
+
+        let result = process_message(message, &mock_writer, None).await;
+
+        assert!(result.is_ok());
+
+        assert_eq!(fake_client.data_points_written.lock().await.len(), 7);
+
+        // Check the first data point
+        let dp1 = &fake_client.data_points_written.lock().await[0];
+        let mut v = Vec::new();
+        dp1.write_data_point_to(&mut v).unwrap();
+        let s = String::from_utf8(v).unwrap();
+
+        assert_eq!(
+            s,
+            "power_reading,device_id=1234,device_name=dev01 current_ma=23,power_mw=754,voltage_mv=119355 1740947155686000000\n"
         );
     }
 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -1,15 +1,15 @@
-use crate::error::ResultExt;
-use async_trait::async_trait;
-use miette::{Report, Result};
-use regex::Regex;
-use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
 /// MQTT client implementation with support for filtered message subscriptions
 ///
 /// This module provides the core MQTT client functionality, including message
 /// filtering and subscription management.
-use std::collections::HashMap;
-use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc};
-use tokio::sync::Mutex;
+use crate::error::ResultExt;
+use crate::{influxdb::InfluxDBWriter, models::KasaPowerMessage, watchdog::Signal};
+use async_trait::async_trait;
+use miette::{Report, Result};
+use regex::Regex;
+use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
+use std::{collections::HashMap, fmt::Debug, future::Future, pin::Pin, sync::Arc};
+use tokio::sync::{Mutex, mpsc::Sender};
 
 /// Trait for message filtering
 #[async_trait]
@@ -80,7 +80,7 @@ impl Subscription {
     }
 }
 
-impl std::fmt::Debug for Subscription {
+impl Debug for Subscription {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Subscription")
             .field("filter", &self.filter)
@@ -232,13 +232,40 @@ impl MqttClientManager {
     }
 }
 
-impl std::fmt::Debug for MqttClientManager {
+impl Debug for MqttClientManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MqttClientManager")
             .field("client", &self.client)
             .field("subscriptions", &self.subscriptions)
             .finish()
     }
+}
+
+/// Process a message from the Kasa power monitor
+pub async fn process_message(
+    message: &str,
+    influxdb: &InfluxDBWriter,
+    reset_tx: Option<Sender<Signal>>,
+) -> miette::Result<()> {
+    let power_message: KasaPowerMessage =
+        serde_json::from_str(message).with_serde_json_context()?;
+    let readings = power_message.into_readings();
+
+    for reading in readings {
+        tracing::debug!("Writing reading to InfluxDB: {:?}", reading);
+        influxdb
+            .write_power_reading(&reading)
+            .await
+            .expect("Failed to write power reading to InfluxDB");
+    }
+
+    tracing::info!("Resetting watchdog timer");
+
+    if let Some(tx) = reset_tx {
+        tx.send(Signal::Reset).await.ok();
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,18 +1,9 @@
-use bottle_time_processor::error::ResultExt;
+use bottle_time_processor::{error::ResultExt, watchdog::Signal};
 use std::time::Duration;
 use tokio::{
     sync::{mpsc, oneshot},
     time::{Instant, sleep},
 };
-
-/// Signal for interacting with the watchdog.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-#[allow(dead_code)]
-pub enum Signal {
-    #[default]
-    Reset,
-    Stop,
-}
 
 /// Signal on watchdog expiration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use bottle_time_processor::influxdb::InfluxDbClient;
+use influxdb2::models::DataPoint;
+use std::fmt;
+use tokio::sync::Mutex;
+
+/// A fake InfluxDB client for testing.
+pub struct FakeInfluxDbClient {
+    pub data_points_written: Mutex<Vec<DataPoint>>,
+}
+
+/// Implement the trait for the fake InfluxDB client.
+impl FakeInfluxDbClient {
+    #[allow(dead_code)]
+    /// Create a new instance of the fake InfluxDB client.
+    pub fn new() -> Self {
+        Self {
+            data_points_written: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl fmt::Display for FakeInfluxDbClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FakeInfluxDbClient")
+    }
+}
+
+// If you’re implementing a trait for testing, do so here with #[async_trait]:
+#[async_trait]
+impl InfluxDbClient for FakeInfluxDbClient {
+    async fn write_data_point(&self, _bucket: &str, point: DataPoint) -> Result<(), miette::Error> {
+        let mut data_points = self.data_points_written.lock().await;
+        data_points.push(point);
+        Ok(())
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,5 @@
+mod common;
+
 #[test]
 fn test_add() {
     assert_eq!(bottle_time_processor::add(3, 2), 5);

--- a/tests/mqtt_integration_test.rs
+++ b/tests/mqtt_integration_test.rs
@@ -1,0 +1,39 @@
+use crate::common::FakeInfluxDbClient;
+use bottle_time_processor::{
+    influxdb::InfluxDBWriter, mqtt_client::process_message, watchdog::Signal,
+};
+use influxdb2::models::WriteDataPoint;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+mod common; // Import the common helper module
+
+#[tokio::test]
+async fn test_process_message() {
+    let fake_client = Arc::new(FakeInfluxDbClient::new());
+    // Mock setup
+    let mock_writer = InfluxDBWriter::with_client(fake_client.clone(), "test_bucket".to_string());
+
+    // Sample power readings
+    let message = r#"{"alias":"dev01","deviceId":"1234","power_total":7,"voltages_mv":[119355,119355,119276,119276,119171,119171,119171],"currents_ma":[23,23,23,23,23,23,22],"powers_mw":[754,757,757,739,739,770,770],"timestamps":[1740947155686,1740947158755,1740947161665,1740947164698,1740947167764,1740947170665,1740947172914],"num_readings":7}"#;
+    let (reset_tx, mut reset_rx) = mpsc::channel(16);
+
+    let result = process_message(message, &mock_writer, Some(reset_tx)).await;
+
+    assert!(result.is_ok());
+
+    assert_eq!(fake_client.data_points_written.lock().await.len(), 7);
+
+    // Check the first data point
+    let dp1 = &fake_client.data_points_written.lock().await[0];
+    let mut v = Vec::new();
+    dp1.write_data_point_to(&mut v).unwrap();
+    let s = String::from_utf8(v).unwrap();
+
+    assert_eq!(
+        s,
+        "power_reading,device_id=1234,device_name=dev01 current_ma=23,power_mw=754,voltage_mv=119355 1740947155686000000\n"
+    );
+
+    assert_eq!(reset_rx.recv().await.unwrap(), Signal::Reset);
+}


### PR DESCRIPTION
- Add tests for process_message in mqtt using the split out influxdb
- Allow a stub client to be passed to InfluxDBWriter for testing
