### PR TITLE
Further expand test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools",
  "num-traits",
@@ -410,6 +411,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ systemd = { version = "0.10", default-features = false, features = [], optional 
 openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { version = "0.5", features = ["async_tokio"] }
 proptest = "1.1"
 
 [metadata.docs.rs]

--- a/benches/a_benchmark.rs
+++ b/benches/a_benchmark.rs
@@ -1,13 +1,72 @@
+use bottle_time_processor::{
+    influxdb::InfluxDBWriter, models::KasaPowerMessage,
+    test_utils::message_bench_utils::FakeInfluxDbClient,
+};
 use criterion::{Criterion, criterion_group, criterion_main};
+use std::sync::Arc;
+
+use tokio::runtime::Runtime;
 
 pub fn add_benchmark(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
     let mut rvg = bottle_time_processor::test_utils::Rvg::deterministic();
-    let int_val_1 = rvg.sample(&(0..100i32));
-    let int_val_2 = rvg.sample(&(0..100i32));
 
-    c.bench_function("add", |b| {
-        b.iter(|| {
-            bottle_time_processor::add(int_val_1, int_val_2);
+    // Create FakeInfluxDbClient
+    let fake_influxdb_client = FakeInfluxDbClient::new(false);
+    let influx_writer =
+        InfluxDBWriter::with_client(Arc::new(fake_influxdb_client), "test_bucket".to_string());
+
+    c.bench_function("message_into_reading", move |b| {
+        let message = Arc::new(KasaPowerMessage {
+            alias: "Test Device".to_string(),
+            device_id: "test-device".to_string(),
+            power_total: 0,
+            voltages_mv: vec![
+                rvg.sample(&(11000..13000i32)),
+                rvg.sample(&(11000..13000i32)),
+                rvg.sample(&(11000..13000i32)),
+            ],
+            currents_ma: vec![
+                rvg.sample(&(23..1300i32)),
+                rvg.sample(&(23..1300i32)),
+                rvg.sample(&(23..1300i32)),
+            ],
+            powers_mw: vec![
+                rvg.sample(&(800..1300i32)),
+                rvg.sample(&(800..1300i32)),
+                rvg.sample(&(800..1300i32)),
+            ],
+            timestamps: vec![
+                rvg.sample(&(1614556800..1614556860i64)),
+                rvg.sample(&(1614556861..1614556920i64)),
+                rvg.sample(&(1614556921..1614556980i64)),
+            ],
+            num_readings: 3,
+        });
+        b.iter(move || {
+            let _readings = <KasaPowerMessage as Clone>::clone(&message)
+                .clone()
+                .into_readings();
+        })
+    });
+
+    let reading = KasaPowerMessage {
+        alias: "Test Device".to_string(),
+        device_id: "test-device".to_string(),
+        power_total: 0,
+        voltages_mv: vec![12000],
+        currents_ma: vec![100],
+        powers_mw: vec![1200],
+        timestamps: vec![1614556800],
+        num_readings: 1,
+    }
+    .into_readings()
+    .pop()
+    .unwrap();
+
+    c.bench_function("write_power_reading", |b| {
+        b.to_async(&rt).iter(|| async {
+            influx_writer.write_power_reading(&reading).await.unwrap();
         })
     });
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - "tests"
   - "benches"
+  - "src/test_utils"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,31 +7,10 @@
 
 //! bottle-time-processor
 
-use tokio_graceful_shutdown::SubsystemHandle;
-
 /// Test utilities.
 #[cfg(any(test, feature = "test_utils"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test_utils")))]
 pub mod test_utils;
-
-/// Add two integers together.
-pub fn add(a: i32, b: i32) -> i32 {
-    a + b
-}
-
-/// Multiplies two integers together.
-pub fn mult(a: i32, b: i32) -> i32 {
-    a * b
-}
-
-/// A dummy task that will run until a shutdown is requested.
-pub async fn dummy_task(subsys: SubsystemHandle) -> miette::Result<()> {
-    tracing::info!("dummy_task started.");
-    subsys.on_shutdown_requested().await;
-    tracing::info!("dummy_task stopped.");
-
-    Ok(())
-}
 
 /// Error handling utilities
 pub mod error;
@@ -62,10 +41,5 @@ pub mod watchdog {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[test]
-    fn test_mult() {
-        assert_eq!(mult(3, 2), 6);
-    }
+    // use super::*;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 //! bottle-time-processor
 
 use crate::watchdog::{Expired, Watchdog};
-use bottle_time_processor::dummy_task;
 use futures::future::pending;
 use miette::Error;
 use std::{pin::Pin, time::Duration};
@@ -73,13 +72,11 @@ async fn main() -> miette::Result<()> {
     // Setup the watchdog timer
     let watchdog: Pin<Box<Watchdog>> = Box::pin(watchdog::setup_watchdog(&opts).await?);
 
-    // let (reset_tx, expire_rx) = watchdog.run();
     let (reset_tx, reset_rx) = mpsc::channel(16);
     let (expire_tx, expire_rx) = oneshot::channel();
 
     // Initialize and run subsystems
     Toplevel::new(|s| async move {
-        s.start(SubsystemBuilder::new("dummy_task", dummy_task));
         s.start(SubsystemBuilder::new(
             "watchdog_loop",
             |_subsys| async move { watchdog.watchdog_loop(reset_rx, expire_tx).await },

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Local, TimeZone};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 /// Represents a power measurement message from a Kasa smart plug device
 pub struct KasaPowerMessage {
     /// Human-readable name of the device

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -62,12 +62,22 @@ async fn subscribe_to_topic(
 mod tests {
     use super::*;
     use crate::command_line::Options;
+    use async_trait::async_trait;
+    use bottle_time_processor::mqtt_client::MqttClientInterface;
     use clap::Parser;
+    use rumqttc::QoS;
+    use std::{
+        fmt::{Display, Formatter},
+        sync::Arc,
+    };
+    use tokio::sync::Mutex;
 
     fn get_default_opts() -> Options {
         Options::try_parse_from(
             vec![
                 "bottle-time-processor",
+                "--influxdb-url",
+                "http://localhost:8086",
                 "--influxdb-token",
                 "token",
                 "--influxdb-org",
@@ -80,10 +90,55 @@ mod tests {
                 "user",
                 "--password",
                 "pass",
+                "--topic",
+                "username/feeds/topic1",
             ]
             .iter(),
         )
         .unwrap()
+    }
+
+    #[derive(Debug)]
+    pub struct FakeMqttClient {
+        // This field records subscribe calls for later verification.
+        pub subscribe_calls: Mutex<Vec<(String, QoS)>>,
+    }
+
+    impl FakeMqttClient {
+        pub fn new() -> Self {
+            Self {
+                subscribe_calls: Mutex::new(vec![]),
+            }
+        }
+    }
+
+    impl Display for FakeMqttClient {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FakeMqttClient")
+        }
+    }
+
+    #[async_trait]
+    impl MqttClientInterface for FakeMqttClient {
+        async fn subscribe(&self, topic: &str, qos: QoS) -> miette::Result<()> {
+            self.subscribe_calls
+                .lock()
+                .await
+                .push((topic.to_string(), qos));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_setup_mqtt() {
+        let opts = get_default_opts();
+
+        let mqtt_client_manager = setup_mqtt(&opts, None).await.unwrap();
+
+        assert_eq!(
+            mqtt_client_manager.to_string(),
+            "MqttClientManager { client: RealMqttClient { client: AsyncClient { request_tx: Sender } }, subscriptions: Mutex { data: {\"username/feeds/topic1\": [Subscription { filter: None, callback: \"<function>\" }]} }"
+        );
     }
 
     #[tokio::test]
@@ -108,5 +163,19 @@ mod tests {
             writer.to_string(),
             "InfluxDBWriter { client: { url: \"http://localhost:8086/\", org: \"org\", }, bucket: \"bucket\" }"
         );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_to_topic() {
+        let opts = get_default_opts();
+        let fake_client = Arc::new(FakeMqttClient::new());
+        let mqtt_client_manager = MqttClientManager::with_client(fake_client);
+        let influxdb = create_influxdb_writer(&opts);
+
+        subscribe_to_topic(&mqtt_client_manager, &opts, influxdb, None)
+            .await
+            .unwrap();
+
+        assert_eq!(mqtt_client_manager.subscriptions.lock().await.len(), 1);
     }
 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -7,7 +7,7 @@ use crate::{influxdb::InfluxDBWriter, models::KasaPowerMessage, watchdog::Signal
 use async_trait::async_trait;
 use miette::{Report, Result};
 use regex::Regex;
-use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
+use rumqttc::{AsyncClient, ConnectionError, Event, EventLoop, MqttOptions, QoS};
 use std::{
     collections::HashMap,
     fmt::{Debug, Display, Formatter},
@@ -192,30 +192,44 @@ impl MqttClientManager {
         Ok(())
     }
 
+    /// Handle an incoming event message
+    pub async fn handle_event_message(
+        msg: Result<Event, ConnectionError>,
+        subscriptions: Arc<Mutex<HashMap<String, Vec<Subscription>>>>,
+    ) -> Result<(), ConnectionError> {
+        match msg {
+            Ok(notification) => {
+                if let Event::Incoming(rumqttc::Packet::Publish(msg)) = notification {
+                    let subs = subscriptions.lock().await;
+                    if let Some(topic_subs) = subs.get(&msg.topic) {
+                        let payload = String::from_utf8_lossy(&msg.payload);
+                        for subscription in topic_subs {
+                            if let Err(e) = subscription.handle_message(&payload).await {
+                                tracing::error!("Error in message callback: {}", e);
+                            }
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!("MQTT connection error: {}", e);
+                Err(e)
+            }
+        }
+    }
+
     /// Spawn a task to handle MQTT events
     pub async fn spawn_event_handler(&self, mut eventloop: EventLoop) -> Result<()> {
         let subscriptions = Arc::clone(&self.subscriptions);
 
         tokio::task::spawn(async move {
             loop {
-                match eventloop.poll().await {
-                    Ok(notification) => {
-                        if let rumqttc::Event::Incoming(rumqttc::Packet::Publish(msg)) =
-                            notification
-                        {
-                            let subs = subscriptions.lock().await;
-                            if let Some(topic_subs) = subs.get(&msg.topic) {
-                                let payload = String::from_utf8_lossy(&msg.payload);
-                                for subscription in topic_subs {
-                                    if let Err(e) = subscription.handle_message(&payload).await {
-                                        tracing::error!("Error in message callback: {}", e);
-                                    }
-                                }
-                            }
-                        }
-                    }
+                let msg = eventloop.poll().await;
+                match Self::handle_event_message(msg, subscriptions.clone()).await {
+                    Ok(()) => (),
                     Err(e) => {
-                        tracing::error!("MQTT connection error: {}", e);
+                        tracing::error!("Error handling MQTT event: {}", e);
                         break;
                     }
                 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -8,7 +8,13 @@ use async_trait::async_trait;
 use miette::{Report, Result};
 use regex::Regex;
 use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
-use std::{collections::HashMap, fmt::Debug, future::Future, pin::Pin, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display, Formatter},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+};
 use tokio::sync::{Mutex, mpsc::Sender};
 
 /// Trait for message filtering
@@ -20,7 +26,7 @@ pub trait MessageFilter: Send + Sync + Debug {
 
 /// Simple contains string filter
 #[derive(Debug)]
-pub struct ContainsFilter(String);
+pub struct ContainsFilter(pub String);
 
 impl MessageFilter for ContainsFilter {
     fn matches(&self, message: &str) -> bool {
@@ -56,13 +62,15 @@ impl std::fmt::Debug for FunctionFilter {
 }
 
 /// Callback type for message handlers
-type MessageCallback =
+pub type MessageCallback =
     Box<dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + Sync>;
 
 /// Structure to hold subscription information
-struct Subscription {
-    filter: Option<Box<dyn MessageFilter>>,
-    callback: MessageCallback,
+pub struct Subscription {
+    /// Optional message filter
+    pub filter: Option<Box<dyn MessageFilter>>,
+    /// Message callback
+    pub callback: MessageCallback,
 }
 
 impl Subscription {
@@ -91,7 +99,7 @@ impl Debug for Subscription {
 
 /// An abstraction over the MQTT client functionality allowing dependency injection.
 #[async_trait]
-pub trait MqttClientInterface: Send + Sync + Debug {
+pub trait MqttClientInterface: Send + Sync + Debug + Display {
     /// Subscribe to a topic with a given QoS
     async fn subscribe(&self, topic: &str, qos: QoS) -> Result<()>;
 }
@@ -100,6 +108,12 @@ pub trait MqttClientInterface: Send + Sync + Debug {
 #[derive(Debug)]
 pub struct RealMqttClient {
     client: AsyncClient,
+}
+
+impl Display for RealMqttClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RealMqttClient {{ client: {:?} }}", self.client)
+    }
 }
 
 #[async_trait]
@@ -114,8 +128,10 @@ impl MqttClientInterface for RealMqttClient {
 
 /// The MQTT client manager
 pub struct MqttClientManager {
-    client: Arc<dyn MqttClientInterface>,
-    subscriptions: Arc<Mutex<HashMap<String, Vec<Subscription>>>>,
+    /// The MQTT client
+    pub client: Arc<dyn MqttClientInterface>,
+    /// The subscriptions of this client
+    pub subscriptions: Arc<Mutex<HashMap<String, Vec<Subscription>>>>,
 }
 
 impl MqttClientManager {
@@ -241,6 +257,22 @@ impl Debug for MqttClientManager {
     }
 }
 
+// impl Display for dyn MqttClientInterface {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         write!(f, "<MqttClientInterface>")
+//     }
+// }
+
+impl Display for MqttClientManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MqttClientManager {{ client: {}, subscriptions: {:?}",
+            self.client, self.subscriptions
+        )
+    }
+}
+
 /// Process a message from the Kasa power monitor
 pub async fn process_message(
     message: &str,
@@ -271,31 +303,6 @@ pub async fn process_message(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[derive(Debug)]
-    struct FakeMqttClient {
-        // This field records subscribe calls for later verification.
-        pub subscribe_calls: Mutex<Vec<(String, QoS)>>,
-    }
-
-    impl FakeMqttClient {
-        fn new() -> Self {
-            Self {
-                subscribe_calls: Mutex::new(vec![]),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl MqttClientInterface for FakeMqttClient {
-        async fn subscribe(&self, topic: &str, qos: QoS) -> Result<()> {
-            self.subscribe_calls
-                .lock()
-                .await
-                .push((topic.to_string(), qos));
-            Ok(())
-        }
-    }
 
     #[test]
     fn test_contains_filter() {
@@ -361,56 +368,6 @@ mod tests {
         })
     }
 
-    #[tokio::test]
-    async fn test_handle_message() {
-        let manager = MqttClientManager {
-            client: Arc::new(FakeMqttClient::new()),
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
-        };
-
-        let topic = "test".to_string();
-        let payload = "test message".to_string();
-
-        let filter = ContainsFilter("test".to_string());
-
-        let callback: MessageCallback = get_msg_cb("test message".to_string());
-
-        let subscription = Subscription {
-            filter: Some(Box::new(filter)),
-            callback: Box::new(callback),
-        };
-
-        {
-            let mut subs = manager.subscriptions.lock().await;
-            subs.insert(topic.clone(), vec![subscription]);
-        }
-        manager.handle_message(&topic, &payload).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_handle_message_none_filter() {
-        let manager = MqttClientManager {
-            client: Arc::new(FakeMqttClient::new()),
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
-        };
-
-        let topic = "test".to_string();
-        let payload = "test message".to_string();
-
-        let callback: MessageCallback = get_msg_cb("test message".to_string());
-
-        let subscription = Subscription {
-            filter: None,
-            callback: Box::new(callback),
-        };
-
-        {
-            let mut subs = manager.subscriptions.lock().await;
-            subs.insert(topic.clone(), vec![subscription]);
-        }
-        manager.handle_message(&topic, &payload).await.unwrap();
-    }
-
     #[test]
     fn test_format_for_subscription() {
         let filter = ContainsFilter("test".to_string());
@@ -427,48 +384,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_format_for_mqtt_manager() {
-        let manager = MqttClientManager {
-            client: Arc::new(FakeMqttClient::new()),
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
-        };
-
-        assert_eq!(
-            format!("{:?}", manager),
-            format!(
-                "MqttClientManager {{ client: {:?}, subscriptions: Mutex {{ data: {{}} }} }}",
-                FakeMqttClient::new()
-            )
-        )
-    }
-
     #[tokio::test]
     async fn test_new_mqtt_manager() {
         let (manager, _) =
             MqttClientManager::new(MqttOptions::new("test", "localhost", 1883)).unwrap();
         assert_eq!(manager.subscriptions.lock().await.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_mqtt_manager_subscribe() {
-        let manager = MqttClientManager {
-            client: Arc::new(FakeMqttClient::new()),
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
-        };
-
-        let topic = "test".to_string();
-        let filter = ContainsFilter("test".to_string());
-        let callback: MessageCallback = get_msg_cb("test message".to_string());
-
-        manager
-            .subscribe(topic.clone(), Some(Box::new(filter)), callback)
-            .await
-            .unwrap();
-
-        let subs = manager.subscriptions.lock().await;
-        assert_eq!(subs.len(), 1);
-        assert_eq!(subs.get(&topic).unwrap().len(), 1);
     }
 
     #[ignore]

--- a/src/test_utils/message_bench_utils.rs
+++ b/src/test_utils/message_bench_utils.rs
@@ -1,0 +1,89 @@
+use crate::{influxdb::InfluxDbClient, mqtt_client::MqttClientInterface};
+use async_trait::async_trait;
+use influxdb2::models::DataPoint;
+use rumqttc::QoS;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
+use tokio::sync::Mutex;
+
+/// A fake InfluxDB client for testing.
+#[derive(Debug)]
+pub struct FakeInfluxDbClient {
+    data_points_written: Option<Mutex<Vec<DataPoint>>>,
+}
+
+/// Implement the trait for the fake InfluxDB client.
+impl FakeInfluxDbClient {
+    #[allow(dead_code)]
+    /// Create a new instance of the fake InfluxDB client.
+    pub fn new(track_points: bool) -> Self {
+        Self {
+            data_points_written: if track_points {
+                Some(Mutex::new(Vec::new()))
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl fmt::Display for FakeInfluxDbClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FakeInfluxDbClient")
+    }
+}
+
+// If you’re implementing a trait for testing, do so here with #[async_trait]:
+#[async_trait]
+impl InfluxDbClient for FakeInfluxDbClient {
+    async fn write_data_point(&self, _bucket: &str, point: DataPoint) -> Result<(), miette::Error> {
+        match &self.data_points_written {
+            Some(x) => {
+                let mut data_points = x.lock().await;
+                data_points.push(point);
+            }
+            None => {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FakeMqttClient {
+    // This field records subscribe calls for later verification.
+    subscribe_calls: Option<Mutex<Vec<(String, QoS)>>>,
+}
+
+impl FakeMqttClient {
+    #[allow(dead_code)]
+    fn new(track_points: bool) -> Self {
+        Self {
+            subscribe_calls: if track_points {
+                Some(Mutex::new(vec![]))
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl Display for FakeMqttClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FakeMqttClient")
+    }
+}
+
+#[async_trait]
+impl MqttClientInterface for FakeMqttClient {
+    async fn subscribe(&self, topic: &str, qos: QoS) -> miette::Result<()> {
+        match &self.subscribe_calls {
+            Some(x) => {
+                x.lock().await.push((topic.to_string(), qos));
+            }
+            None => {}
+        }
+        Ok(())
+    }
+}

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "test_utils")]
+/// Utilities for testing messages.
+pub mod message_bench_utils;
 /// Random value generator for sampling data.
 #[cfg(feature = "test_utils")]
 mod rvg;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,14 @@
 use async_trait::async_trait;
-use bottle_time_processor::influxdb::InfluxDbClient;
+use bottle_time_processor::{
+    influxdb::InfluxDbClient,
+    mqtt_client::{MessageCallback, MqttClientInterface},
+};
 use influxdb2::models::DataPoint;
-use std::fmt;
+use rumqttc::QoS;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 use tokio::sync::Mutex;
 
 /// A fake InfluxDB client for testing.
@@ -34,4 +41,52 @@ impl InfluxDbClient for FakeInfluxDbClient {
         data_points.push(point);
         Ok(())
     }
+}
+
+#[derive(Debug)]
+pub struct FakeMqttClient {
+    // This field records subscribe calls for later verification.
+    pub subscribe_calls: Mutex<Vec<(String, QoS)>>,
+}
+
+impl FakeMqttClient {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            subscribe_calls: Mutex::new(vec![]),
+        }
+    }
+}
+
+impl Display for FakeMqttClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FakeMqttClient")
+    }
+}
+
+#[async_trait]
+impl MqttClientInterface for FakeMqttClient {
+    async fn subscribe(&self, topic: &str, qos: QoS) -> miette::Result<()> {
+        self.subscribe_calls
+            .lock()
+            .await
+            .push((topic.to_string(), qos));
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+/// Get a message callback for testing.
+pub fn get_msg_cb(expected_msg: String) -> MessageCallback {
+    Box::new(move |msg: String| {
+        Box::pin({
+            {
+                let value = expected_msg.clone();
+                async move {
+                    assert_eq!(msg, value);
+                    Ok(())
+                }
+            }
+        })
+    })
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,1 @@
 mod common;
-
-#[test]
-fn test_add() {
-    assert_eq!(bottle_time_processor::add(3, 2), 5);
-}

--- a/tests/mqtt_integration_test.rs
+++ b/tests/mqtt_integration_test.rs
@@ -7,6 +7,7 @@ use bottle_time_processor::{
     watchdog::Signal,
 };
 use influxdb2::models::WriteDataPoint;
+use rumqttc::{ConnectReturnCode, ConnectionError, Event, QoS};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{Mutex, mpsc};
 
@@ -127,4 +128,44 @@ async fn test_mqtt_manager_subscribe() {
     let subs = manager.subscriptions.lock().await;
     assert_eq!(subs.len(), 1);
     assert_eq!(subs.get(&topic).unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_handle_event_message() {
+    let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+
+    let topic = "test".to_string();
+    let payload = "test message".to_string();
+
+    let callback: MessageCallback = get_msg_cb("test message".to_string());
+
+    let subscription = Subscription {
+        filter: None,
+        callback: Box::new(callback),
+    };
+
+    {
+        let mut subs = subscriptions.lock().await;
+        subs.insert(topic.clone(), vec![subscription]);
+    }
+
+    let msg = Ok(Event::Incoming(rumqttc::Packet::Publish(
+        rumqttc::Publish {
+            topic: topic.clone(),
+            pkid: 0,
+            payload: payload.into(),
+            dup: false,
+            qos: QoS::AtMostOnce,
+            retain: false,
+        },
+    )));
+
+    let result = MqttClientManager::handle_event_message(msg, subscriptions.clone()).await;
+    assert!(result.is_ok());
+
+    let msg = Err(ConnectionError::ConnectionRefused(
+        ConnectReturnCode::BadClientId,
+    ));
+    let result = MqttClientManager::handle_event_message(msg, subscriptions.clone()).await;
+    assert!(result.is_err());
 }

--- a/tests/mqtt_integration_test.rs
+++ b/tests/mqtt_integration_test.rs
@@ -1,10 +1,14 @@
-use crate::common::FakeInfluxDbClient;
+use crate::common::{FakeInfluxDbClient, FakeMqttClient, get_msg_cb};
 use bottle_time_processor::{
-    influxdb::InfluxDBWriter, mqtt_client::process_message, watchdog::Signal,
+    influxdb::InfluxDBWriter,
+    mqtt_client::{
+        ContainsFilter, MessageCallback, MqttClientManager, Subscription, process_message,
+    },
+    watchdog::Signal,
 };
 use influxdb2::models::WriteDataPoint;
-use std::sync::Arc;
-use tokio::sync::mpsc;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{Mutex, mpsc};
 
 mod common; // Import the common helper module
 
@@ -36,4 +40,91 @@ async fn test_process_message() {
     );
 
     assert_eq!(reset_rx.recv().await.unwrap(), Signal::Reset);
+}
+
+#[tokio::test]
+async fn test_handle_message() {
+    let manager = MqttClientManager {
+        client: Arc::new(FakeMqttClient::new()),
+        subscriptions: Arc::new(Mutex::new(HashMap::new())),
+    };
+
+    let topic = "test".to_string();
+    let payload = "test message".to_string();
+
+    let filter = ContainsFilter("test".to_string());
+
+    let callback: MessageCallback = get_msg_cb("test message".to_string());
+
+    let subscription = Subscription {
+        filter: Some(Box::new(filter)),
+        callback: Box::new(callback),
+    };
+
+    {
+        let mut subs = manager.subscriptions.lock().await;
+        subs.insert(topic.clone(), vec![subscription]);
+    }
+    manager.handle_message(&topic, &payload).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_handle_message_none_filter() {
+    let manager = MqttClientManager {
+        client: Arc::new(FakeMqttClient::new()),
+        subscriptions: Arc::new(Mutex::new(HashMap::new())),
+    };
+
+    let topic = "test".to_string();
+    let payload = "test message".to_string();
+
+    let callback: MessageCallback = get_msg_cb("test message".to_string());
+
+    let subscription = Subscription {
+        filter: None,
+        callback: Box::new(callback),
+    };
+
+    {
+        let mut subs = manager.subscriptions.lock().await;
+        subs.insert(topic.clone(), vec![subscription]);
+    }
+    manager.handle_message(&topic, &payload).await.unwrap();
+}
+
+#[test]
+fn test_format_for_mqtt_manager() {
+    let manager = MqttClientManager {
+        client: Arc::new(FakeMqttClient::new()),
+        subscriptions: Arc::new(Mutex::new(HashMap::new())),
+    };
+
+    assert_eq!(
+        format!("{:?}", manager),
+        format!(
+            "MqttClientManager {{ client: {:?}, subscriptions: Mutex {{ data: {{}} }} }}",
+            FakeMqttClient::new()
+        )
+    )
+}
+
+#[tokio::test]
+async fn test_mqtt_manager_subscribe() {
+    let manager = MqttClientManager {
+        client: Arc::new(FakeMqttClient::new()),
+        subscriptions: Arc::new(Mutex::new(HashMap::new())),
+    };
+
+    let topic = "test".to_string();
+    let filter = ContainsFilter("test".to_string());
+    let callback: MessageCallback = get_msg_cb("test message".to_string());
+
+    manager
+        .subscribe(topic.clone(), Some(Box::new(filter)), callback)
+        .await
+        .unwrap();
+
+    let subs = manager.subscriptions.lock().await;
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs.get(&topic).unwrap().len(), 1);
 }


### PR DESCRIPTION
- Move more tests to the integration testing area
- Cleanup some dead code
- Unfortunately, it looks like I had to duplicate the FakeMqttClient to get it to work in different modules
- Add a bit more testing for mqtt.rs
- Add tests for MqttClientManager::handle_event_message